### PR TITLE
Upgrade to tui v0.10 and add crossterm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,17 @@ keywords = ["tui", "log", "logger", "widget", "dispatcher"]
 [badges]
 travis-ci = { repository = "gin66/tui-logger" }
 
+[features]
+default = ["tui-termion"]
+tui-termion = ["tui/termion", "termion"]
+tui-crossterm = ["tui/crossterm", "crossterm"]
+
 [dependencies]
 log = "0.4"
 chrono = "0.4"
-tui = "0.10"
-termion = "1.5"
+tui = { version = "0.10", default-features = false }
+crossterm = { version = "0.17", optional = true }
+termion = { version = "1.5", optional = true }
 lazy_static = "1.0"
 fxhash = "0.2"
 parking_lot = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "gin66/tui-logger" }
 [dependencies]
 log = "0.4"
 chrono = "0.4"
-tui = "0.9"
+tui = "0.10"
 termion = "1.5"
 lazy_static = "1.0"
 fxhash = "0.2"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [ ] Allow configuration of target dependent loglevel specifically for file logging
 - [ ] Avoid duplicating of target, module and filename in every log record
 - [ ] Simultaneous modification of all targets' display/hot logging loglevel by key command
+- [X] Support both `termion` and `crossterm` backends of `tui`
 
 ## Smart Widget
 
@@ -88,6 +89,16 @@ fn main() {
 ```
 
 For use of the widget please check examples/demo.rs
+
+## Using the `crossterm` backend
+
+Use these in `Cargo.toml`:
+
+```toml
+[dependencies]
+tui = { version = "0.10", default-features = false, features = ["crossterm"]}
+tui-logger = { version = "0.4", default-features = false, features = ["tui-crossterm"] }
+```
 
 ## THANKS TO
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -168,7 +168,7 @@ fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
         .state(&mut app.states[sel])
         .dispatcher(app.dispatcher.clone());
     t.render_widget(tui_sm, chunks[1]);
-    let tui_w :TuiLoggerWidget = TuiLoggerWidget::default()
+    let tui_w: TuiLoggerWidget = TuiLoggerWidget::default()
         .block(
             Block::default()
                 .title("Independent Tui Logger View")
@@ -177,7 +177,7 @@ fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
                 .borders(Borders::ALL),
         )
         .style(Style::default().fg(Color::White).bg(Color::Black));
-    t.render_widget(tui_w , chunks[2]);
+    t.render_widget(tui_w, chunks[2]);
     if let Some(percent) = app.opt_info_cnt {
         let guage = Gauge::default()
             .block(Block::default().borders(Borders::ALL).title("Progress"))

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -111,7 +111,7 @@ fn main() -> std::result::Result<(), std::io::Error> {
 }
 
 fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
-    let tabs = vec!["V1", "V2", "V3", "V4"];
+    let tabs: Vec<tui::text::Spans> = vec!["V1".into(), "V2".into(), "V3".into(), "V4".into()];
     let sel = *app.selected_tab.borrow();
     let sel_tab = if sel + 1 < tabs.len() { sel + 1 } else { 0 };
     let sel_stab = if sel > 0 { sel - 1 } else { tabs.len() - 1 };
@@ -136,6 +136,7 @@ fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
     }
 
     let block = Block::default().borders(Borders::ALL);
+    let inner_area = block.inner(size);
     t.render_widget(block, size);
 
     let mut constraints = vec![
@@ -149,17 +150,15 @@ fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints(constraints)
-        .split(size);
+        .split(inner_area);
 
-    let tabs = Tabs::default()
+    let tabs = Tabs::new(tabs)
         .block(Block::default().borders(Borders::ALL))
-        .titles(&tabs)
-        .highlight_style(Style::default().modifier(Modifier::REVERSED))
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .select(sel);
     t.render_widget(tabs, chunks[0]);
 
     let tui_sm = TuiLoggerSmartWidget::default()
-        .border_style(Style::default().fg(Color::Black))
         .style_error(Style::default().fg(Color::Red))
         .style_debug(Style::default().fg(Color::Green))
         .style_warn(Style::default().fg(Color::Yellow))
@@ -172,7 +171,6 @@ fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
         .block(
             Block::default()
                 .title("Independent Tui Logger View")
-                .title_style(Style::default().fg(Color::White).bg(Color::Black))
                 .border_style(Style::default().fg(Color::White).bg(Color::Black))
                 .borders(Borders::ALL),
         )
@@ -181,11 +179,11 @@ fn draw_frame<B: Backend>(t: &mut Frame<B>, size: Rect, app: &mut App) {
     if let Some(percent) = app.opt_info_cnt {
         let guage = Gauge::default()
             .block(Block::default().borders(Borders::ALL).title("Progress"))
-            .style(
+            .gauge_style(
                 Style::default()
                     .fg(Color::Black)
                     .bg(Color::White)
-                    .modifier(Modifier::ITALIC),
+                    .add_modifier(Modifier::ITALIC),
             )
             .percent(percent);
         t.render_widget(guage, chunks[3]);

--- a/src/event/crossterm_impl.rs
+++ b/src/event/crossterm_impl.rs
@@ -1,0 +1,83 @@
+use crossterm::event::{KeyCode, KeyEvent};
+
+pub use crossterm::event::Event;
+
+pub(crate) fn is_space_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Char(' '),
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_up_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Up,
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_down_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Down,
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_left_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Left,
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_right_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Right,
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_plus_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Char('+'),
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_minus_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Char('-'),
+            modifiers: _,
+        })
+    )
+}
+
+pub(crate) fn is_h_key(evt: &Event) -> bool {
+    matches!(
+        evt,
+        &Event::Key(KeyEvent {
+            code: KeyCode::Char('h'),
+            modifiers: _,
+        })
+    )
+}

--- a/src/event/termion_impl.rs
+++ b/src/event/termion_impl.rs
@@ -1,0 +1,35 @@
+use termion::event::Key;
+
+pub use termion::event::Event;
+
+pub(crate) fn is_space_key(evt: &Event) -> bool {
+    &Event::Key(Key::Char(' ')) == evt
+}
+
+pub(crate) fn is_up_key(evt: &Event) -> bool {
+    &Event::Key(Key::Up) == evt
+}
+
+pub(crate) fn is_down_key(evt: &Event) -> bool {
+    &Event::Key(Key::Down) == evt
+}
+
+pub(crate) fn is_left_key(evt: &Event) -> bool {
+    &Event::Key(Key::Left) == evt
+}
+
+pub(crate) fn is_right_key(evt: &Event) -> bool {
+    &Event::Key(Key::Right) == evt
+}
+
+pub(crate) fn is_plus_key(evt: &Event) -> bool {
+    &Event::Key(Key::Char('+')) == evt
+}
+
+pub(crate) fn is_minus_key(evt: &Event) -> bool {
+    &Event::Key(Key::Char('-')) == evt
+}
+
+pub(crate) fn is_h_key(evt: &Event) -> bool {
+    &Event::Key(Key::Char('h')) == evt
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@ use std::rc::Rc;
 use chrono::{DateTime, Local};
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use parking_lot::Mutex;
-use termion::event::*;
 use tui::buffer::Buffer;
 use tui::layout::{Constraint, Direction, Layout, Rect};
 use tui::style::{Modifier, Style};
@@ -119,6 +118,15 @@ use tui::widgets::{Block, Borders, Widget};
 
 mod circular;
 mod dispatcher;
+
+#[cfg(feature = "tui-crossterm")]
+#[path = "event/crossterm_impl.rs"]
+mod event;
+#[cfg(feature = "tui-termion")]
+#[path = "event/termion_impl.rs"]
+mod event;
+
+use crate::event::Event;
 
 pub use crate::circular::CircularBuffer;
 pub use crate::dispatcher::{Dispatcher, EventListener};
@@ -530,7 +538,7 @@ impl<'b> TuiLoggerTargetWidget<'b> {
             let state = self.state.clone();
             if state.borrow().hide_off {
                 dispatcher.borrow_mut().add_listener(move |evt| {
-                    if &Event::Key(Key::Char(' ')) == evt {
+                    if event::is_space_key(evt) {
                         state.borrow_mut().hide_off = false;
                         true
                     } else {
@@ -539,7 +547,7 @@ impl<'b> TuiLoggerTargetWidget<'b> {
                 });
             } else {
                 dispatcher.borrow_mut().add_listener(move |evt| {
-                    if &Event::Key(Key::Char(' ')) == evt {
+                    if event::is_space_key(evt) {
                         state.borrow_mut().hide_off = true;
                         true
                     } else {
@@ -551,7 +559,7 @@ impl<'b> TuiLoggerTargetWidget<'b> {
                 let state = self.state.clone();
                 if self.state.borrow().selected.is_none() {
                     dispatcher.borrow_mut().add_listener(move |evt| {
-                        if &Event::Key(Key::Down) == evt || &Event::Key(Key::Up) == evt {
+                        if event::is_down_key(evt) || event::is_up_key(evt) {
                             state.borrow_mut().selected = Some(0);
                             true
                         } else {
@@ -564,7 +572,7 @@ impl<'b> TuiLoggerTargetWidget<'b> {
                     if selected > 0 {
                         let state = state.clone();
                         dispatcher.borrow_mut().add_listener(move |evt| {
-                            if &Event::Key(Key::Up) == evt {
+                            if event::is_up_key(evt) {
                                 state.borrow_mut().selected = Some(selected - 1);
                                 true
                             } else {
@@ -575,7 +583,7 @@ impl<'b> TuiLoggerTargetWidget<'b> {
                     if selected + 1 < max_selected {
                         let state = self.state.clone();
                         dispatcher.borrow_mut().add_listener(move |evt| {
-                            if &Event::Key(Key::Down) == evt {
+                            if event::is_down_key(evt) {
                                 state.borrow_mut().selected = Some(selected + 1);
                                 true
                             } else {
@@ -595,10 +603,10 @@ impl<'b> TuiLoggerTargetWidget<'b> {
                     };
                     let state = self.state.clone();
                     dispatcher.borrow_mut().add_listener(move |evt| {
-                        if &Event::Key(Key::Left) == evt {
+                        if event::is_left_key(evt) {
                             state.borrow_mut().config.set(&t, less);
                             true
-                        } else if &Event::Key(Key::Right) == evt {
+                        } else if event::is_right_key(evt) {
                             state.borrow_mut().config.set(&t, more);
                             true
                         } else {
@@ -613,10 +621,10 @@ impl<'b> TuiLoggerTargetWidget<'b> {
                             return;
                         };
                     dispatcher.borrow_mut().add_listener(move |evt| {
-                        if &Event::Key(Key::Char('-')) == evt {
+                        if event::is_minus_key(evt) {
                             set_level_for_target(&t, less);
                             true
-                        } else if &Event::Key(Key::Char('+')) == evt {
+                        } else if event::is_plus_key(evt) {
                             set_level_for_target(&t, more);
                             true
                         } else {
@@ -1093,7 +1101,7 @@ impl Widget for TuiLoggerSmartWidget {
             let state = self.state.clone();
             if hide_target {
                 dispatcher.borrow_mut().add_listener(move |evt| {
-                    if &Event::Key(Key::Char('h')) == evt {
+                    if event::is_h_key(evt) {
                         state.borrow_mut().hide_target = false;
                         true
                     } else {
@@ -1102,7 +1110,7 @@ impl Widget for TuiLoggerSmartWidget {
                 });
             } else {
                 dispatcher.borrow_mut().add_listener(move |evt| {
-                    if &Event::Key(Key::Char('h')) == evt {
+                    if event::is_h_key(evt) {
                         state.borrow_mut().hide_target = true;
                         true
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl<'b> Default for TuiLoggerTargetWidget<'b> {
             style_show: Style::default().modifier(Modifier::REVERSED),
             highlight_style: Style::default().modifier(Modifier::REVERSED),
             state: Rc::new(RefCell::new(TuiWidgetInnerState::new())),
-            targets: vec![], 
+            targets: vec![],
             event_dispatcher: None,
         }
     }
@@ -508,10 +508,7 @@ impl<'b> TuiLoggerTargetWidget<'b> {
         self.highlight_style = style;
         self
     }
-    fn inner_state(
-        mut self,
-        state: Rc<RefCell<TuiWidgetInnerState>>,
-    ) -> TuiLoggerTargetWidget<'b> {
+    fn inner_state(mut self, state: Rc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerTargetWidget<'b> {
         self.state = state.clone();
         self
     }
@@ -848,10 +845,7 @@ impl<'b> TuiLoggerWidget<'b> {
         self.style_debug = Some(style);
         self
     }
-    fn inner_state(
-        mut self,
-        state: Rc<RefCell<TuiWidgetInnerState>>,
-    ) -> TuiLoggerWidget<'b> {
+    fn inner_state(mut self, state: Rc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerWidget<'b> {
         self.state = state.clone();
         self
     }
@@ -1010,7 +1004,7 @@ impl TuiLoggerSmartWidget {
         self.border_style = style;
         self
     }
-    pub fn style(mut self, style: Style) ->  TuiLoggerSmartWidget {
+    pub fn style(mut self, style: Style) -> TuiLoggerSmartWidget {
         self.style = Some(style);
         self
     }
@@ -1052,17 +1046,14 @@ impl TuiLoggerSmartWidget {
     }
 }
 impl EventListener<Event> for TuiLoggerSmartWidget {
-    fn dispatcher(
-        mut self,
-        dispatcher: Rc<RefCell<Dispatcher<Event>>>,
-    ) -> TuiLoggerSmartWidget {
+    fn dispatcher(mut self, dispatcher: Rc<RefCell<Dispatcher<Event>>>) -> TuiLoggerSmartWidget {
         self.event_dispatcher = Some(dispatcher.clone());
         self
     }
 }
 impl Widget for TuiLoggerSmartWidget {
     /// Nothing to draw for combo widget
-    fn render(mut self, area: Rect, buf: &mut Buffer) { 
+    fn render(mut self, area: Rect, buf: &mut Buffer) {
         let entries_s = {
             let mut tui_lock = TUI_LOGGER.inner.lock();
             let first_timestamp = {
@@ -1119,7 +1110,7 @@ impl Widget for TuiLoggerSmartWidget {
             }
         }
         if hide_target {
-           let tui_lw = TuiLoggerWidget::default()
+            let tui_lw = TuiLoggerWidget::default()
                 .block(
                     Block::default()
                         .title(&self.title_log)
@@ -1176,8 +1167,8 @@ impl Widget for TuiLoggerSmartWidget {
                 .opt_style_show(self.style_show)
                 .inner_state(self.state.clone())
                 .opt_dispatcher(self.event_dispatcher.take());
-             tui_ltw.render(chunks[0], buf);
-             let title = format!("{}  [log={:.1}/s]", self.title_log, entries_s);
+            tui_ltw.render(chunks[0], buf);
+            let title = format!("{}  [log={:.1}/s]", self.title_log, entries_s);
             let tui_lw = TuiLoggerWidget::default()
                 .block(
                     Block::default()
@@ -1193,7 +1184,7 @@ impl Widget for TuiLoggerSmartWidget {
                 .opt_style_debug(self.style_debug)
                 .opt_style_trace(self.style_trace)
                 .inner_state(self.state.clone());
-             tui_lw.render(chunks[1], buf);
+            tui_lw.render(chunks[1], buf);
         }
     }
 }


### PR DESCRIPTION
This upgrades `tui-rs` to v0.10 and also add support for the `crossterm` backend so that it can be used on Windows (which `termion` does not support). The backend can be selected via Cargo feature flags.

When running the example on Windows with the crossterm backend, the highlights won't be applied unless [this patch](https://github.com/fdehau/tui-rs/pull/368) is included in tui-rs.

Note: I've added some info regarding the crossterm backend to the readme. It references `tui-logger` version `0.4`. However, since this PR bumps the dependency version, the version of this crate should be bumped to `0.5`. The readme will then also needs to be updated.