### PR TITLE
Elide receiver lifetime on TuiLoggerWidget::state()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,12 +865,10 @@ impl<'b> TuiLoggerWidget<'b> {
         self.style_debug = Some(style);
         self
     }
-
     fn inner_state(mut self, state: Rc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerWidget<'b> {
         self.state = state.clone();
         self
     }
-
     pub fn state(&mut self, state: &TuiWidgetState) -> &mut TuiLoggerWidget<'b> {
         self.state = state.inner.clone();
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,11 +865,13 @@ impl<'b> TuiLoggerWidget<'b> {
         self.style_debug = Some(style);
         self
     }
+
     fn inner_state(mut self, state: Rc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerWidget<'b> {
         self.state = state.clone();
         self
     }
-    pub fn state(&'b mut self, state: &TuiWidgetState) -> &mut TuiLoggerWidget<'b> {
+
+    pub fn state(&mut self, state: &TuiWidgetState) -> &mut TuiLoggerWidget<'b> {
         self.state = state.inner.clone();
         self
     }


### PR DESCRIPTION
Currently, the signature for TuiLoggerWidget::state is 
`pub fn state(&'b mut self, state: &TuiWidgetState) -> &mut TuiLoggerWidget<'b>` 
which mutably borrows the widget for the remainder of its lifetime. This prevents the widget from being moved and drawn. By removing the explicit lifetime on `&mut self`, the borrow is limited to the lifetime of the returned borrow.

Without this change, I wasn't able to use this widget - it works now!

Thanks