### PR TITLE
Fix: allow `TuiWidgetState` to be sent over threads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!
 //! - Capturing of log messages by the logger
 //! - Selection of levels for display in the logging message view
-//!  
+//!
 //! The two columns have the following meaning:
 //!
 //! - Code EWIDT: E stands for Error, W for Warn, Info, Debug and Trace.
@@ -55,7 +55,7 @@
 //!   + Normal characters show enabled capturing of a log level per target
 //!   + If any of EWIDT are not shown, then the respective log level is not captured
 //! - Target of the log events can be defined in the log e.g. `warn!(target: "demo", "Log message");`
-//!  
+//!
 //! ## Smart Widget Key Commands
 //! ```ignore
 //! |  KEY     | ACTION
@@ -73,7 +73,7 @@
 //! | ESCAPE   | Exit page mode and go back to scrolling mode
 //! | SPACE    | Toggles hiding of targets, which have logfilter set to off
 //! ```
-//!  
+//!
 //! The mapping of key to action has to be done in the application. The respective TuiWidgetEvent
 //! has to be provided to TuiWidgetState::transition().
 //!
@@ -135,7 +135,7 @@ use std::fs::OpenOptions;
 use std::io;
 use std::io::Write;
 use std::mem;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use chrono::{DateTime, Local};
 use log::{Level, LevelFilter, Log, Metadata, Record};
@@ -518,13 +518,13 @@ impl TuiWidgetInnerState {
 /// This struct contains the shared state of a TuiLoggerWidget and a TuiLoggerTargetWidget.
 #[derive(Default)]
 pub struct TuiWidgetState {
-    inner: Rc<RefCell<TuiWidgetInnerState>>,
+    inner: Arc<RefCell<TuiWidgetInnerState>>,
 }
 impl TuiWidgetState {
     /// Create a new TuiWidgetState
     pub fn new() -> TuiWidgetState {
         TuiWidgetState {
-            inner: Rc::new(RefCell::new(TuiWidgetInnerState::new())),
+            inner: Arc::new(RefCell::new(TuiWidgetInnerState::new())),
         }
     }
     pub fn set_level_for_target(&self, target: &str, levelfilter: LevelFilter) -> &TuiWidgetState {
@@ -546,7 +546,7 @@ pub struct TuiLoggerTargetWidget<'b> {
     style_hide: Style,
     style_off: Option<Style>,
     highlight_style: Style,
-    state: Rc<RefCell<TuiWidgetInnerState>>,
+    state: Arc<RefCell<TuiWidgetInnerState>>,
     targets: Vec<String>,
 }
 impl<'b> Default for TuiLoggerTargetWidget<'b> {
@@ -559,7 +559,7 @@ impl<'b> Default for TuiLoggerTargetWidget<'b> {
             style_hide: Style::default(),
             style_show: Style::default().add_modifier(Modifier::REVERSED),
             highlight_style: Style::default().add_modifier(Modifier::REVERSED),
-            state: Rc::new(RefCell::new(TuiWidgetInnerState::new())),
+            state: Arc::new(RefCell::new(TuiWidgetInnerState::new())),
             targets: vec![],
         }
     }
@@ -619,7 +619,10 @@ impl<'b> TuiLoggerTargetWidget<'b> {
         self.highlight_style = style;
         self
     }
-    fn inner_state(mut self, state: Rc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerTargetWidget<'b> {
+    fn inner_state(
+        mut self,
+        state: Arc<RefCell<TuiWidgetInnerState>>,
+    ) -> TuiLoggerTargetWidget<'b> {
         self.state = state;
         self
     }
@@ -766,7 +769,7 @@ pub struct TuiLoggerWidget<'b> {
     style_debug: Option<Style>,
     style_trace: Option<Style>,
     style_info: Option<Style>,
-    state: Rc<RefCell<TuiWidgetInnerState>>,
+    state: Arc<RefCell<TuiWidgetInnerState>>,
 }
 impl<'b> Default for TuiLoggerWidget<'b> {
     fn default() -> TuiLoggerWidget<'b> {
@@ -779,7 +782,7 @@ impl<'b> Default for TuiLoggerWidget<'b> {
             style_debug: None,
             style_trace: None,
             style_info: None,
-            state: Rc::new(RefCell::new(TuiWidgetInnerState::new())),
+            state: Arc::new(RefCell::new(TuiWidgetInnerState::new())),
         }
     }
 }
@@ -848,7 +851,7 @@ impl<'b> TuiLoggerWidget<'b> {
         self.style_debug = Some(style);
         self
     }
-    fn inner_state(mut self, state: Rc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerWidget<'b> {
+    fn inner_state(mut self, state: Arc<RefCell<TuiWidgetInnerState>>) -> TuiLoggerWidget<'b> {
         self.state = state;
         self
     }
@@ -955,11 +958,7 @@ impl<'b> Widget for TuiLoggerWidget<'b> {
                 let rem_width = la_width - indent as usize;
                 while remain.chars().count() > rem_width {
                     let remove: String = remain.chars().take(rem_width).collect();
-                    wrapped_lines.push((
-                        style,
-                        indent,
-                        remove,
-                    ));
+                    wrapped_lines.push((style, indent, remove));
                     remain = remain.chars().skip(rem_width).collect();
                 }
                 wrapped_lines.push((style, indent, remain.to_owned()));
@@ -1005,7 +1004,7 @@ pub struct TuiLoggerSmartWidget<'a> {
     style_show: Option<Style>,
     style_hide: Option<Style>,
     style_off: Option<Style>,
-    state: Rc<RefCell<TuiWidgetInnerState>>,
+    state: Arc<RefCell<TuiWidgetInnerState>>,
 }
 impl<'a> Default for TuiLoggerSmartWidget<'a> {
     fn default() -> Self {
@@ -1024,7 +1023,7 @@ impl<'a> Default for TuiLoggerSmartWidget<'a> {
             style_show: None,
             style_hide: None,
             style_off: None,
-            state: Rc::new(RefCell::new(TuiWidgetInnerState::new())),
+            state: Arc::new(RefCell::new(TuiWidgetInnerState::new())),
         }
     }
 }


### PR DESCRIPTION
My application uses a separate UI thread, which requires `TuiWidgetState` to implement `Send`. This PR "upgrades" all `Rc`s and `RefCell`s to their thread-safe alternatives.

Note: I have not adjusted the semver yet!