### PR TITLE
Update to latest tui dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ travis-ci = { repository = "gin66/tui-logger" }
 [dependencies]
 log = "0.4"
 chrono = "0.4"
-tui = { version = "0.17", default-features = false }
+tui = { version = "0.18", default-features = false }
 lazy_static = "1.0"
 fxhash = "0.2"
 parking_lot = "0"
 slog = "2.5"
 
 [dev-dependencies]
-tui = { version = "0.17", default-features = true, features = ["termion"] } 
+tui = { version = "0.18", default-features = true, features = ["termion"] }
 termion = "1.5"
 


### PR DESCRIPTION
tui had another breaking release, which unfortunately means that anything building on top that new version (e.g. latest tuirealm 1.6) isn't compatible with tui-logger anymore. Fortunately, tui-logger seems to be unaffected by that breaking release, so this PR just bumps to the next major.