### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 tui = { version = "0.18", default-features = false }
 lazy_static = "1.0"
 fxhash = "0.2"
-parking_lot = "0"
+parking_lot = "0.12"
 slog = { version = "2.5", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.