### PR TITLE
Implement `Eq` for `TuiWidgetEvent`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ impl Drain {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum TuiWidgetEvent {
     SpaceKey,
     UpKey,


### PR DESCRIPTION
This PR adds [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html) implementation for `TuiWidgetEvent`.

I personally need this for testing (asserting the enum fields) in my application.
