### PR TITLE
Disable default features of `chrono`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "gin66/tui-logger" }
 
 [dependencies]
 log = "0.4"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tui = { version = "0.19", default-features = false, package = "tui", optional = true }
 ratatui = { version = "0.20", default-features = false, package = "ratatui", optional = true }
 tracing = {version = "0.1.37", optional = true}


### PR DESCRIPTION
To avoid bringing `time` v0.1.x into dependency graph, see https://github.com/time-rs/time/issues/293

Fixes #36 
