### PR TITLE
Add support for ratatui  0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "gin66/tui-logger" }
 log = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tui = { version = "0.19", default-features = false, package = "tui", optional = true }
-ratatui = { version = "0.20", default-features = false, package = "ratatui", optional = true }
+ratatui = { version = "0.21.0", default-features = false, package = "ratatui", optional = true }
 tracing = {version = "0.1.37", optional = true}
 tracing-subscriber = {version = "0.3", optional = true}
 lazy_static = "1.0"


### PR DESCRIPTION
This PR updates dependency for new ratatui version. 

Additionally, based on `ratatui-suppport` feature it switches usage of deprecated `Spans` struct to `Line`. For that rather hacky way of handling API differences was required to make it possible, but it gets rid of deprecation warnings during compilation for ratatui support.