### PR TITLE
chore: bump ratatui version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,23 @@ travis-ci = { repository = "gin66/tui-logger" }
 log = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tui = { version = "0.19", default-features = false, package = "tui", optional = true }
-ratatui = { version = "0.22.0", default-features = false, package = "ratatui", optional = true }
-tracing = {version = "0.1.37", optional = true}
-tracing-subscriber = {version = "0.3", optional = true}
+ratatui = { version = "0.23.0", default-features = false, package = "ratatui", optional = true }
+tracing = { version = "0.1.37", optional = true }
+tracing-subscriber = { version = "0.3", optional = true }
 lazy_static = "1.0"
 fxhash = "0.2"
 parking_lot = "0.12"
 slog = { version = "2.7.0", optional = true }
 
 # Optional features for demo. Unfortunately cannot move to dep-dependencies
-termion = {version = "1.5", optional = true }
-crossterm = {version = "0.27", optional = true }
+termion = { version = "1.5", optional = true }
+crossterm = { version = "0.27", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"
 
 [features]
-default = ["tui","tui/termion", "examples-tui-termion"]
+default = ["tui", "tui/termion", "examples-tui-termion"]
 tui-rs = ["tui"]
 slog-support = ["slog"]
 ratatui-support = ["ratatui"]


### PR DESCRIPTION
This PR updates the `ratatui` dependency to the latest version, ensuring compatibility with the latest features and improvements. No functional code changes are introduced in this commit.