### PR TITLE
Use `Cell::set_symbol` for better heap handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,11 +859,11 @@ impl<'b> Widget for TuiLoggerTargetWidget<'b> {
                     } else if let Some(style_off) = self.style_off {
                         style_off
                     } else {
-                        cell.symbol = " ".to_string();
+                        cell.set_symbol(" ");
                         continue;
                     };
                     cell.set_style(cell_style);
-                    cell.symbol = sym.to_string();
+                    cell.set_symbol(sym);
                 }
                 buf.set_stringn(la_left + 5, la_top + i as u16, ":", la_width, self.style);
                 buf.set_stringn(


### PR DESCRIPTION
tui-logger directly replaces `symbol` field of `Cell`. However there is more efficient API `Cell::set_symbol`. This method reuses the heap buffer in `String` so reallocation doesn't happen.