### PR TITLE
Upgrade ratatui to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "gin66/tui-logger" }
 [dependencies]
 log = "0.4"
 chrono = { version = "^0.4.20", default-features = false, features = ["clock"] }
-ratatui = { version = "0.24.0", default-features = false, package = "ratatui" }
+ratatui = { version = "0.25.0", default-features = false, package = "ratatui" }
 tracing = {version = "0.1.37", optional = true}
 tracing-subscriber = {version = "0.3", optional = true}
 lazy_static = "1.0"


### PR DESCRIPTION
I was having issues with version mismatch in my project using `ratatui` `0.25.0`, so had to upgrade it.

Fixes #53 