### PR TITLE
feat!: derive `Copy` on TuiWidgetEvent and TuiLoggerLevelOutput

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -143,40 +143,40 @@ fn main() -> std::result::Result<(), std::io::Error> {
                                 app.selected_tab = sel_tab;
                             }
                             Key::Char(' ') => {
-                                state.transition(&TuiWidgetEvent::SpaceKey);
+                                state.transition(TuiWidgetEvent::SpaceKey);
                             }
                             Key::Esc => {
-                                state.transition(&TuiWidgetEvent::EscapeKey);
+                                state.transition(TuiWidgetEvent::EscapeKey);
                             }
                             Key::PageUp => {
-                                state.transition(&TuiWidgetEvent::PrevPageKey);
+                                state.transition(TuiWidgetEvent::PrevPageKey);
                             }
                             Key::PageDown => {
-                                state.transition(&TuiWidgetEvent::NextPageKey);
+                                state.transition(TuiWidgetEvent::NextPageKey);
                             }
                             Key::Up => {
-                                state.transition(&TuiWidgetEvent::UpKey);
+                                state.transition(TuiWidgetEvent::UpKey);
                             }
                             Key::Down => {
-                                state.transition(&TuiWidgetEvent::DownKey);
+                                state.transition(TuiWidgetEvent::DownKey);
                             }
                             Key::Left => {
-                                state.transition(&TuiWidgetEvent::LeftKey);
+                                state.transition(TuiWidgetEvent::LeftKey);
                             }
                             Key::Right => {
-                                state.transition(&TuiWidgetEvent::RightKey);
+                                state.transition(TuiWidgetEvent::RightKey);
                             }
                             Key::Char('+') => {
-                                state.transition(&TuiWidgetEvent::PlusKey);
+                                state.transition(TuiWidgetEvent::PlusKey);
                             }
                             Key::Char('-') => {
-                                state.transition(&TuiWidgetEvent::MinusKey);
+                                state.transition(TuiWidgetEvent::MinusKey);
                             }
                             Key::Char('h') => {
-                                state.transition(&TuiWidgetEvent::HideKey);
+                                state.transition(TuiWidgetEvent::HideKey);
                             }
                             Key::Char('f') => {
-                                state.transition(&TuiWidgetEvent::FocusKey);
+                                state.transition(TuiWidgetEvent::FocusKey);
                             }
                             _ => (),
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Important note for `tui`
 //!
-//! The `tui` crate has been archived and `ratatui` has taken over. 
+//! The `tui` crate has been archived and `ratatui` has taken over.
 //! In order to avoid supporting compatibility for an inactive crate,
 //! the v0.9.x releases are the last to support `tui`. In case future bug fixes
 //! are needed, the branch `tui_legacy` has been created to track changes to 0.9.x releases.
@@ -535,7 +535,7 @@ impl Drain {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum TuiWidgetEvent {
     SpaceKey,
     UpKey,
@@ -573,9 +573,9 @@ impl TuiWidgetInnerState {
     pub fn new() -> TuiWidgetInnerState {
         TuiWidgetInnerState::default()
     }
-    fn transition(&mut self, event: &TuiWidgetEvent) {
+    fn transition(&mut self, event: TuiWidgetEvent) {
         use TuiWidgetEvent::*;
-        match *event {
+        match event {
             SpaceKey => {
                 self.hide_off ^= true;
             }
@@ -652,7 +652,7 @@ impl TuiWidgetState {
         self.inner.lock().config.set(target, levelfilter);
         self
     }
-    pub fn transition(&mut self, event: &TuiWidgetEvent) {
+    pub fn transition(&mut self, event: TuiWidgetEvent) {
         self.inner.lock().transition(event);
     }
 }
@@ -877,7 +877,7 @@ impl<'b> Widget for TuiLoggerTargetWidget<'b> {
 
 /// The TuiLoggerWidget shows the logging messages in an endless scrolling view.
 /// It is controlled by a TuiWidgetState for selected events.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 pub enum TuiLoggerLevelOutput {
     Abbreviated,
     Long,


### PR DESCRIPTION
These enums are small and simple enough to be `Copy`. This change
simplifies calling code to not have to use `&` when passing or
comparing these enums.

See https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy
for justification.

BREAKING CHANGE: `TuiWidgetEvent::transition()` method now takes a
`TuiWidgetEvent` by value instead of by reference.
