### PR TITLE
Update and simplify demo example

### DIFF
--- a/.github/workflows/build_examples.yml
+++ b/.github/workflows/build_examples.yml
@@ -2,19 +2,18 @@ name: Build examples
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Build examples with ratatui and termion
-      run: cargo build --examples
-    - name: Build example with ratatui and crossterm
-      run: cargo build --examples --no-default-features -F examples-crossterm 
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build examples with ratatui and termion
+        run: cargo build --examples --features termion
+      - name: Build example with ratatui and crossterm
+        run: cargo build --examples --features crossterm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "gin66/tui-logger" }
 [dependencies]
 log = "0.4"
 chrono = { version = "^0.4.20", default-features = false, features = ["clock"] }
-ratatui = { version = "^0.25.0", default-features = false, package = "ratatui" }
+ratatui = { version = ">=0.25.0", default-features = false}
 tracing = {version = "0.1.37", optional = true}
 tracing-subscriber = {version = "0.3", optional = true}
 lazy_static = "1.0"
@@ -24,18 +24,18 @@ fxhash = "0.2"
 parking_lot = "0.12"
 slog = { version = "2.7.0", optional = true }
 
-# Optional features for demo. Unfortunately cannot move to dev-dependencies
-termion = {version = "1.5", optional = true }
-crossterm = {version = "0.27", optional = true }
-
 [dev-dependencies]
-env_logger = "0.10.0"
+# the crate is compatible with ratatui >=0.25.0, but the demo uses features from 0.26.0
+ratatui = { version = "0.26.0", default-features = false}
+anyhow = "1.0.79"
+env_logger = "0.11.1"
+termion = {version = "3.0.0" }
+crossterm = {version = "0.27"}
 
 [features]
-default = ["ratatui/termion", "examples-termion"]
 slog-support = ["slog"]
 tracing-support = ["tracing", "tracing-subscriber"]
 
-# This features are exclusively used by examples/demo.rs
-examples-termion = ["termion", "ratatui/termion"]
-examples-crossterm = ["crossterm", "ratatui/crossterm"]
+# only necessary for the demo, the crate does has no dependencies on these
+crossterm = ["ratatui/crossterm"]
+termion = ["ratatui/termion"]

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,58 @@
+# This is a configuration file for the bacon tool
+#
+# Bacon repository: https://github.com/Canop/bacon
+# Complete help on configuration: https://dystroy.org/bacon/config/
+# You can also check bacon's own bacon.toml file
+#  as an example: https://github.com/Canop/bacon/blob/main/bacon.toml
+
+default_job = "check"
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+# This is a helpful job to check that the demo compiles with the crossterm
+# feature enabled. This and the termion feature are mutually exclusive.
+[jobs.check-crossterm]
+command = ["cargo", "check", "--all-targets", "--features", "crossterm", "--color", "always"]
+need_stdout = false
+
+# This is a helpful job to check that the demo compiles with the termion
+# feature enabled. This and the crossterm feature are mutually exclusive.
+[jobs.check-termion]
+command = ["cargo", "check", "--all-targets", "--features", "termion", "--color", "always"]
+need_stdout = false
+
+[jobs.clippy]
+command = [
+    "cargo", "clippy",
+    "--color", "always",
+]
+need_stdout = false
+
+[jobs.test]
+command = [
+    "cargo", "test", "--libs", "--color", "always",
+    "--", "--color", "always", # see https://github.com/Canop/bacon/issues/124
+]
+need_stdout = true
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# If the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal global prefs.toml file instead.
+[keybindings]
+# alt-m = "job:my-job"
+1 = "job:check-crossterm"
+2 = "job:check-termion"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -143,40 +143,40 @@ fn main() -> std::result::Result<(), std::io::Error> {
                                 app.selected_tab = sel_tab;
                             }
                             Key::Char(' ') => {
-                                state.transition(&TuiWidgetEvent::SpaceKey);
+                                state.transition(TuiWidgetEvent::SpaceKey);
                             }
                             Key::Esc => {
-                                state.transition(&TuiWidgetEvent::EscapeKey);
+                                state.transition(TuiWidgetEvent::EscapeKey);
                             }
                             Key::PageUp => {
-                                state.transition(&TuiWidgetEvent::PrevPageKey);
+                                state.transition(TuiWidgetEvent::PrevPageKey);
                             }
                             Key::PageDown => {
-                                state.transition(&TuiWidgetEvent::NextPageKey);
+                                state.transition(TuiWidgetEvent::NextPageKey);
                             }
                             Key::Up => {
-                                state.transition(&TuiWidgetEvent::UpKey);
+                                state.transition(TuiWidgetEvent::UpKey);
                             }
                             Key::Down => {
-                                state.transition(&TuiWidgetEvent::DownKey);
+                                state.transition(TuiWidgetEvent::DownKey);
                             }
                             Key::Left => {
-                                state.transition(&TuiWidgetEvent::LeftKey);
+                                state.transition(TuiWidgetEvent::LeftKey);
                             }
                             Key::Right => {
-                                state.transition(&TuiWidgetEvent::RightKey);
+                                state.transition(TuiWidgetEvent::RightKey);
                             }
                             Key::Char('+') => {
-                                state.transition(&TuiWidgetEvent::PlusKey);
+                                state.transition(TuiWidgetEvent::PlusKey);
                             }
                             Key::Char('-') => {
-                                state.transition(&TuiWidgetEvent::MinusKey);
+                                state.transition(TuiWidgetEvent::MinusKey);
                             }
                             Key::Char('h') => {
-                                state.transition(&TuiWidgetEvent::HideKey);
+                                state.transition(TuiWidgetEvent::HideKey);
                             }
                             Key::Char('f') => {
-                                state.transition(&TuiWidgetEvent::FocusKey);
+                                state.transition(TuiWidgetEvent::FocusKey);
                             }
                             _ => (),
                         }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,319 +1,345 @@
-use std::io;
-use std::sync::mpsc;
-use std::{thread, time};
+use std::{io, sync::mpsc, thread, time};
 
-use log::LevelFilter;
 use log::*;
-
-#[cfg(feature = "crossterm")]
-use crossterm::event::KeyCode as Key;
-#[cfg(feature = "crossterm")]
-use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
-
-#[cfg(feature = "termion")]
-use termion::{
-    event::{Event, Key},
-    input::{MouseTerminal, TermRead},
-    raw::IntoRawMode,
-    screen::AlternateScreen,
-};
-
-#[cfg(feature = "examples-crossterm")]
-use ratatui::backend::CrosstermBackend as SelectedBackend;
-#[cfg(feature = "examples-termion")]
-use ratatui::backend::TermionBackend as SelectedBackend;
-use ratatui::prelude::*;
-use ratatui::widgets::*;
-
+use ratatui::{prelude::*, widgets::*};
 use tui_logger::*;
 
+/// Choose the backend depending on the selected feature (crossterm or termion). This is a mutually
+/// exclusive feature, so only one of them can be enabled at a time.
+#[cfg(all(feature = "crossterm", not(feature = "termion")))]
+use self::crossterm_backend::*;
+#[cfg(all(feature = "termion", not(feature = "crossterm")))]
+use self::termion_backend::*;
+#[cfg(not(any(feature = "crossterm", feature = "termion")))]
+compile_error!("One of the features 'crossterm' or 'termion' must be enabled.");
+#[cfg(all(feature = "crossterm", feature = "termion"))]
+compile_error!("Only one of the features 'crossterm' and 'termion' can be enabled.");
+
 struct App {
+    mode: AppMode,
     states: Vec<TuiWidgetState>,
-    tabs: Vec<String>,
+    tab_names: Vec<&'static str>,
     selected_tab: usize,
-    opt_info_cnt: Option<u16>,
+    progress_counter: Option<u16>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum AppMode {
+    #[default]
+    Run,
+    Quit,
 }
 
 #[derive(Debug)]
 enum AppEvent {
     UiEvent(Event),
-    LoopCnt(Option<u16>),
+    CounterChanged(Option<u16>),
 }
 
-fn demo_application(tx: mpsc::Sender<AppEvent>) {
-    let one_second = time::Duration::from_millis(1_000);
-    let mut lp_cnt = (1..=100).into_iter();
-    loop {
-        trace!(target:"DEMO", "Sleep one second");
-        thread::sleep(one_second);
-        trace!(target:"DEMO", "Issue log entry for each level");
-        error!(target:"error", "an error");
-        warn!(target:"warn", "a warning");
-        trace!(target:"trace", "a trace");
-        debug!(target:"debug", "a debug");
-        info!(target:"info", "an info");
-        tx.send(AppEvent::LoopCnt(lp_cnt.next())).unwrap();
-    }
-}
-
-fn main() -> std::result::Result<(), std::io::Error> {
-    init_logger(LevelFilter::Trace).unwrap();
+fn main() -> anyhow::Result<()> {
+    init_logger(LevelFilter::Trace)?;
     set_default_level(LevelFilter::Trace);
-    info!(target:"DEMO", "Start demo");
+    debug!(target:"App", "Logging initialized");
 
-    #[cfg(feature = "termion")]
-    let backend = {
-        let stdout = io::stdout().into_raw_mode().unwrap();
-        let stdout = MouseTerminal::from(stdout);
-        let stdout = AlternateScreen::from(stdout);
-        SelectedBackend::new(stdout)
-    };
+    let mut terminal = init_terminal()?;
+    terminal.clear()?;
+    terminal.hide_cursor()?;
 
-    #[cfg(feature = "crossterm")]
-    let backend = {
-        // setup terminal
-        enable_raw_mode()?;
-        let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-        SelectedBackend::new(stdout)
-    };
+    App::new().start(&mut terminal)?;
 
-    let mut terminal = Terminal::new(backend).unwrap();
-    terminal.clear().unwrap();
-    terminal.hide_cursor().unwrap();
-
-    // Use an mpsc::channel to combine stdin events with app events
-    let (tx, rx) = mpsc::channel();
-    let tx_event = tx.clone();
-    thread::spawn({
-        let f = {
-            move || {
-                #[cfg(feature = "termion")]
-                for c in io::stdin().events() {
-                    trace!(target:"DEMO", "Stdin event received {:?}", c);
-                    tx_event.send(AppEvent::UiEvent(c.unwrap())).unwrap();
-                }
-                #[cfg(feature = "crossterm")]
-                while let Ok(c) = event::read() {
-                    trace!(target:"DEMO", "Stdin event received {:?}", c);
-                    tx_event.send(AppEvent::UiEvent(c)).unwrap();
-                }
-            }
-        };
-        f
-    });
-    thread::spawn(move || {
-        demo_application(tx);
-    });
-
-    let mut app = App {
-        states: vec![],
-        tabs: vec!["V1".into(), "V2".into(), "V3".into(), "V4".into()],
-        selected_tab: 0,
-        opt_info_cnt: None,
-    };
-
-    // Here is the main loop
-    for evt in rx {
-        let opt_state = if app.selected_tab < app.states.len() {
-            Some(&mut app.states[app.selected_tab])
-        } else {
-            None
-        };
-        match evt {
-            AppEvent::UiEvent(evt) => {
-                debug!(target: "New event", "{:?}",evt);
-                if let Event::Key(key) = evt {
-                    if let Some(state) = opt_state {
-                        #[cfg(feature = "crossterm")]
-                        let code = key.code;
-                        #[cfg(feature = "termion")]
-                        let code = key;
-
-                        match code {
-                            Key::Char('q') => break,
-                            Key::Char('\t') => {
-                                // tab
-                                let sel = app.selected_tab;
-                                let sel_tab = if sel + 1 < app.tabs.len() { sel + 1 } else { 0 };
-                                app.selected_tab = sel_tab;
-                            }
-                            Key::Char(' ') => {
-                                state.transition(TuiWidgetEvent::SpaceKey);
-                            }
-                            Key::Esc => {
-                                state.transition(TuiWidgetEvent::EscapeKey);
-                            }
-                            Key::PageUp => {
-                                state.transition(TuiWidgetEvent::PrevPageKey);
-                            }
-                            Key::PageDown => {
-                                state.transition(TuiWidgetEvent::NextPageKey);
-                            }
-                            Key::Up => {
-                                state.transition(TuiWidgetEvent::UpKey);
-                            }
-                            Key::Down => {
-                                state.transition(TuiWidgetEvent::DownKey);
-                            }
-                            Key::Left => {
-                                state.transition(TuiWidgetEvent::LeftKey);
-                            }
-                            Key::Right => {
-                                state.transition(TuiWidgetEvent::RightKey);
-                            }
-                            Key::Char('+') => {
-                                state.transition(TuiWidgetEvent::PlusKey);
-                            }
-                            Key::Char('-') => {
-                                state.transition(TuiWidgetEvent::MinusKey);
-                            }
-                            Key::Char('h') => {
-                                state.transition(TuiWidgetEvent::HideKey);
-                            }
-                            Key::Char('f') => {
-                                state.transition(TuiWidgetEvent::FocusKey);
-                            }
-                            _ => (),
-                        }
-                    }
-                }
-            }
-            AppEvent::LoopCnt(opt_cnt) => {
-                trace!(target: "New event", "{:?}",evt);
-                app.opt_info_cnt = opt_cnt;
-            }
-        }
-        terminal.draw(|mut f| {
-            let size = f.size();
-            draw_frame(&mut f, size, &mut app);
-        })?;
-    }
-    #[cfg(feature = "crossterm")]
-    {
-        // restore terminal
-        disable_raw_mode()?;
-        execute!(
-            terminal.backend_mut(),
-            LeaveAlternateScreen,
-            DisableMouseCapture
-        )?;
-    }
-    terminal.show_cursor().unwrap();
-    terminal.clear().unwrap();
+    restore_terminal()?;
+    terminal.clear()?;
 
     Ok(())
 }
 
-fn draw_frame(t: &mut Frame, size: Rect, app: &mut App) {
-    let tabs: Vec<Line> = vec!["V1".into(), "V2".into(), "V3".into(), "V4".into()];
-    let sel = app.selected_tab;
-
-    if app.states.len() <= sel {
-        let tws = TuiWidgetState::new().set_default_display_level(log::LevelFilter::Info);
-        app.states.push(tws);
+impl App {
+    pub fn new() -> App {
+        let states = vec![
+            TuiWidgetState::new().set_default_display_level(LevelFilter::Info),
+            TuiWidgetState::new().set_default_display_level(LevelFilter::Info),
+            TuiWidgetState::new().set_default_display_level(LevelFilter::Info),
+            TuiWidgetState::new().set_default_display_level(LevelFilter::Info),
+        ];
+        let tab_names = vec!["State 1", "State 2", "State 3", "State 4"];
+        App {
+            mode: AppMode::Run,
+            states,
+            tab_names,
+            selected_tab: 0,
+            progress_counter: None,
+        }
     }
 
-    let block = Block::default().borders(Borders::ALL);
-    let inner_area = block.inner(size);
-    t.render_widget(block, size);
+    pub fn start(mut self, terminal: &mut Terminal<impl Backend>) -> anyhow::Result<()> {
+        // Use an mpsc::channel to combine stdin events with app events
+        let (tx, rx) = mpsc::channel();
+        let event_tx = tx.clone();
+        let progress_tx = tx.clone();
 
-    let mut constraints = vec![
-        Constraint::Length(3),
-        Constraint::Percentage(50),
-        Constraint::Percentage(30),
-        Constraint::Min(10),
-    ];
-    if app.opt_info_cnt.is_some() {
-        constraints.push(Constraint::Length(3));
+        thread::spawn(move || input_thread(event_tx));
+        thread::spawn(move || progress_task(progress_tx).unwrap());
+        thread::spawn(move || background_task());
+
+        self.run(terminal, rx)
     }
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(constraints)
-        .split(inner_area);
 
-    let tabs = Tabs::new(tabs)
-        .block(Block::default().borders(Borders::ALL))
-        .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
-        .select(sel);
-    t.render_widget(tabs, chunks[0]);
+    /// Main application loop
+    fn run(
+        &mut self,
+        terminal: &mut Terminal<impl Backend>,
+        rx: mpsc::Receiver<AppEvent>,
+    ) -> anyhow::Result<()> {
+        for event in rx {
+            match event {
+                AppEvent::UiEvent(event) => self.handle_ui_event(event),
+                AppEvent::CounterChanged(value) => self.update_progress_bar(event, value),
+            }
+            if self.mode == AppMode::Quit {
+                break;
+            }
+            self.draw(terminal)?;
+        }
+        Ok(())
+    }
 
-    let tui_sm = TuiLoggerSmartWidget::default()
-        .style_error(Style::default().fg(Color::Red))
-        .style_debug(Style::default().fg(Color::Green))
-        .style_warn(Style::default().fg(Color::Yellow))
-        .style_trace(Style::default().fg(Color::Magenta))
-        .style_info(Style::default().fg(Color::Cyan))
-        .output_separator(':')
-        .output_timestamp(Some("%H:%M:%S".to_string()))
-        .output_level(Some(TuiLoggerLevelOutput::Abbreviated))
-        .output_target(true)
-        .output_file(true)
-        .output_line(true)
-        .state(&mut app.states[sel]);
-    t.render_widget(tui_sm, chunks[1]);
+    fn update_progress_bar(&mut self, event: AppEvent, value: Option<u16>) {
+        trace!(target: "App", "Updating progress bar {:?}",event);
+        self.progress_counter = value;
+        if value.is_none() {
+            info!(target: "App", "Background task finished");
+        }
+    }
 
-    // show two TuiWidgetState side-by-side
-    constraints = vec![Constraint::Percentage(50), Constraint::Percentage(30)];
-    let hchunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints(constraints)
-        .split(chunks[2]);
+    fn handle_ui_event(&mut self, event: Event) {
+        debug!(target: "App", "Handling UI event: {:?}",event);
+        let state = self.selected_state();
 
-    // Example to filter out log entries below Info for targets "trace" and "DEMO"
-    // Best to store TuiWidgetState on application level,
-    // but this temporary usage as shown here works, too.
-    let filter_state = TuiWidgetState::new()
-        .set_default_display_level(log::LevelFilter::Off)
-        .set_level_for_target("New event", log::LevelFilter::Debug)
-        .set_level_for_target("info", log::LevelFilter::Info);
-    let tui_w: TuiLoggerWidget = TuiLoggerWidget::default()
-        .block(
-            Block::default()
-                .title("Independent Tui Logger View")
-                .border_style(Style::default().fg(Color::White).bg(Color::Black))
-                .borders(Borders::ALL),
-        )
-        .output_separator('|')
-        .output_timestamp(Some("%F %H:%M:%S%.3f".to_string()))
-        .output_level(Some(TuiLoggerLevelOutput::Long))
-        .output_target(false)
-        .output_file(false)
-        .output_line(false)
-        .style(Style::default().fg(Color::White).bg(Color::Black))
-        .state(&filter_state);
-    t.render_widget(tui_w, chunks[2]);
+        if let Event::Key(key) = event {
+            #[cfg(feature = "crossterm")]
+            let code = key.code;
 
-    let tui_w: TuiLoggerWidget = TuiLoggerWidget::default()
-        .block(
-            Block::default()
-                .title("Independent Tui Logger View")
-                .border_style(Style::default().fg(Color::White).bg(Color::Black))
-                .borders(Borders::ALL),
-        )
-        .output_separator('|')
-        .output_timestamp(Some("%F %H:%M:%S%.3f".to_string()))
-        .output_level(Some(TuiLoggerLevelOutput::Long))
-        .output_target(false)
-        .output_file(false)
-        .output_line(false)
-        .style(Style::default().fg(Color::White).bg(Color::Black));
-    t.render_widget(tui_w, hchunks[1]);
+            #[cfg(feature = "termion")]
+            let code = key;
 
-    if let Some(percent) = app.opt_info_cnt {
-        let gauge = Gauge::default()
-            .block(Block::default().borders(Borders::ALL).title("Progress"))
-            .gauge_style(
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::White)
-                    .add_modifier(Modifier::ITALIC),
-            )
-            .percent(percent);
-        t.render_widget(gauge, chunks[3]);
+            match code.into() {
+                Key::Char('q') => self.mode = AppMode::Quit,
+                Key::Char('\t') => self.next_tab(),
+                #[cfg(feature = "crossterm")]
+                Key::Tab => self.next_tab(),
+                Key::Char(' ') => state.transition(TuiWidgetEvent::SpaceKey),
+                Key::Esc => state.transition(TuiWidgetEvent::EscapeKey),
+                Key::PageUp => state.transition(TuiWidgetEvent::PrevPageKey),
+                Key::PageDown => state.transition(TuiWidgetEvent::NextPageKey),
+                Key::Up => state.transition(TuiWidgetEvent::UpKey),
+                Key::Down => state.transition(TuiWidgetEvent::DownKey),
+                Key::Left => state.transition(TuiWidgetEvent::LeftKey),
+                Key::Right => state.transition(TuiWidgetEvent::RightKey),
+                Key::Char('+') => state.transition(TuiWidgetEvent::PlusKey),
+                Key::Char('-') => state.transition(TuiWidgetEvent::MinusKey),
+                Key::Char('h') => state.transition(TuiWidgetEvent::HideKey),
+                Key::Char('f') => state.transition(TuiWidgetEvent::FocusKey),
+                _ => (),
+            }
+        }
+    }
+
+    fn selected_state(&mut self) -> &mut TuiWidgetState {
+        &mut self.states[self.selected_tab]
+    }
+
+    fn next_tab(&mut self) {
+        self.selected_tab = (self.selected_tab + 1) % self.tab_names.len();
+    }
+
+    fn draw(&mut self, terminal: &mut Terminal<impl Backend>) -> anyhow::Result<()> {
+        terminal.draw(|frame| {
+            frame.render_widget(self, frame.size());
+        })?;
+        Ok(())
+    }
+}
+
+/// A simulated task that sends a counter value to the UI ranging from 0 to 100 every second.
+fn progress_task(tx: mpsc::Sender<AppEvent>) -> anyhow::Result<()> {
+    for progress in 0..100 {
+        debug!(target:"progress-task", "Send progress to UI thread. Value: {:?}", progress);
+        tx.send(AppEvent::CounterChanged(Some(progress)))?;
+
+        trace!(target:"progress-task", "Sleep one second");
+        thread::sleep(time::Duration::from_millis(1000));
+    }
+    info!(target:"progress-task", "Progress task finished");
+    tx.send(AppEvent::CounterChanged(None))?;
+    Ok(())
+}
+
+/// A background task that logs a log entry for each log level every second.
+fn background_task() {
+    loop {
+        error!(target:"background-task", "an error");
+        warn!(target:"background-task", "a warning");
+        info!(target:"background-task", "an info");
+        debug!(target:"background-task", "a debug");
+        trace!(target:"background-task", "a trace");
+        thread::sleep(time::Duration::from_millis(1000));
+    }
+}
+
+impl Widget for &mut App {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let progress_height = if self.progress_counter.is_some() {
+            3
+        } else {
+            0
+        };
+        let [tabs_area, smart_area, main_area, progress_area, help_area] = Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Fill(50),
+            Constraint::Fill(30),
+            Constraint::Length(progress_height),
+            Constraint::Length(3),
+        ])
+        .areas(area);
+        // show two TuiWidgetState side-by-side
+        let [left, right] = Layout::horizontal([Constraint::Fill(1); 2]).areas(main_area);
+
+        Tabs::new(self.tab_names.iter().cloned())
+            .block(Block::default().title("States").borders(Borders::ALL))
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+            .select(self.selected_tab)
+            .render(tabs_area, buf);
+
+        TuiLoggerSmartWidget::default()
+            .style_error(Style::default().fg(Color::Red))
+            .style_debug(Style::default().fg(Color::Green))
+            .style_warn(Style::default().fg(Color::Yellow))
+            .style_trace(Style::default().fg(Color::Magenta))
+            .style_info(Style::default().fg(Color::Cyan))
+            .output_separator(':')
+            .output_timestamp(Some("%H:%M:%S".to_string()))
+            .output_level(Some(TuiLoggerLevelOutput::Abbreviated))
+            .output_target(true)
+            .output_file(true)
+            .output_line(true)
+            .state(self.selected_state())
+            .render(smart_area, buf);
+
+        // An example of filtering the log output. The left TuiLoggerWidget is filtered to only show
+        // log entries for the "App" target. The right TuiLoggerWidget shows all log entries.
+        let filter_state = TuiWidgetState::new()
+            .set_default_display_level(LevelFilter::Off)
+            .set_level_for_target("App", LevelFilter::Debug)
+            .set_level_for_target("background-task", LevelFilter::Info);
+        TuiLoggerWidget::default()
+            .block(Block::bordered().title("Filtered TuiLoggerWidget"))
+            .output_separator('|')
+            .output_timestamp(Some("%F %H:%M:%S%.3f".to_string()))
+            .output_level(Some(TuiLoggerLevelOutput::Long))
+            .output_target(false)
+            .output_file(false)
+            .output_line(false)
+            .style(Style::default().fg(Color::White))
+            .state(&filter_state)
+            .render(left, buf);
+
+        TuiLoggerWidget::default()
+            .block(Block::bordered().title("Unfiltered TuiLoggerWidget"))
+            .output_separator('|')
+            .output_timestamp(Some("%F %H:%M:%S%.3f".to_string()))
+            .output_level(Some(TuiLoggerLevelOutput::Long))
+            .output_target(false)
+            .output_file(false)
+            .output_line(false)
+            .style(Style::default().fg(Color::White))
+            .render(right, buf);
+
+        if let Some(percent) = self.progress_counter {
+            Gauge::default()
+                .block(Block::bordered().title("progress-task"))
+                .gauge_style((Color::White, Modifier::ITALIC))
+                .percent(percent)
+                .render(progress_area, buf);
+        }
+
+        Text::from(vec![
+            "Q: Quit | Tab: Switch state | ↑/↓: Select target | f: Focus target".into(),
+            "←/→: Display level | +/-: Filter level | Space: Toggle hidden targets".into(),
+            "h: Hide target selector | PageUp/Down: Scroll | Esc: Cancel scroll".into(),
+        ])
+        .style(Color::Gray)
+        .centered()
+        .render(help_area, buf);
+    }
+}
+
+/// A module for crossterm specific code
+#[cfg(feature = "crossterm")]
+mod crossterm_backend {
+    use super::*;
+
+    pub use crossterm::{
+        event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode as Key},
+        execute,
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    };
+
+    pub fn init_terminal() -> io::Result<Terminal<impl Backend>> {
+        trace!(target:"crossterm", "Initializing terminal");
+        enable_raw_mode()?;
+        execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+        let backend = CrosstermBackend::new(io::stdout());
+        Terminal::new(backend)
+    }
+
+    pub fn restore_terminal() -> io::Result<()> {
+        trace!(target:"crossterm", "Restoring terminal");
+        disable_raw_mode()?;
+        execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)
+    }
+
+    pub fn input_thread(tx_event: mpsc::Sender<AppEvent>) -> anyhow::Result<()> {
+        trace!(target:"crossterm", "Starting input thread");
+        while let Ok(event) = event::read() {
+            trace!(target:"crossterm", "Stdin event received {:?}", event);
+            tx_event.send(AppEvent::UiEvent(event))?;
+        }
+        Ok(())
+    }
+}
+
+/// A module for termion specific code
+#[cfg(feature = "termion")]
+mod termion_backend {
+    use super::*;
+    use termion::screen::IntoAlternateScreen;
+    pub use termion::{
+        event::{Event, Key},
+        input::{MouseTerminal, TermRead},
+        raw::IntoRawMode,
+    };
+
+    pub fn init_terminal() -> io::Result<Terminal<impl Backend>> {
+        trace!(target:"termion", "Initializing terminal");
+        let stdout = io::stdout().into_raw_mode()?;
+        let stdout = MouseTerminal::from(stdout);
+        let stdout = stdout.into_alternate_screen()?;
+        let backend = TermionBackend::new(stdout);
+        Terminal::new(backend)
+    }
+
+    pub fn restore_terminal() -> io::Result<()> {
+        trace!(target:"termion", "Restoring terminal");
+        Ok(())
+    }
+
+    pub fn input_thread(tx_event: mpsc::Sender<AppEvent>) -> anyhow::Result<()> {
+        trace!(target:"termion", "Starting input thread");
+        for event in io::stdin().events() {
+            let event = event?;
+            trace!(target:"termion", "Stdin event received {:?}", event);
+            tx_event.send(AppEvent::UiEvent(event))?;
+        }
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! ## Important note for `tui`
 //!
-//! The `tui` crate has been archived and `ratatui` has taken over. 
+//! The `tui` crate has been archived and `ratatui` has taken over.
 //! In order to avoid supporting compatibility for an inactive crate,
 //! the v0.9.x releases are the last to support `tui`. In case future bug fixes
 //! are needed, the branch `tui_legacy` has been created to track changes to 0.9.x releases.
@@ -535,7 +535,7 @@ impl Drain {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum TuiWidgetEvent {
     SpaceKey,
     UpKey,
@@ -573,9 +573,9 @@ impl TuiWidgetInnerState {
     pub fn new() -> TuiWidgetInnerState {
         TuiWidgetInnerState::default()
     }
-    fn transition(&mut self, event: &TuiWidgetEvent) {
+    fn transition(&mut self, event: TuiWidgetEvent) {
         use TuiWidgetEvent::*;
-        match *event {
+        match event {
             SpaceKey => {
                 self.hide_off ^= true;
             }
@@ -652,7 +652,7 @@ impl TuiWidgetState {
         self.inner.lock().config.set(target, levelfilter);
         self
     }
-    pub fn transition(&mut self, event: &TuiWidgetEvent) {
+    pub fn transition(&mut self, event: TuiWidgetEvent) {
         self.inner.lock().transition(event);
     }
 }
@@ -877,7 +877,7 @@ impl<'b> Widget for TuiLoggerTargetWidget<'b> {
 
 /// The TuiLoggerWidget shows the logging messages in an endless scrolling view.
 /// It is controlled by a TuiWidgetState for selected events.
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 pub enum TuiLoggerLevelOutput {
     Abbreviated,
     Long,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,22 +115,16 @@
 //!
 //! ## Demo
 //!
-//! Run demo using termion 1.5:
+//! Run demo using termion:
 //!
 //! ```ignore
-//! cargo run --example demo
-//! ```
-//!
-//! Or more verbosely:
-//!
-//! ```ignore
-//! cargo run --example demo --no-default-features -F examples-termion
+//! cargo run --example demo --features termion
 //! ```
 //!
 //! Run demo with crossterm:
 //!
 //! ```ignore
-//! cargo run --example demo --no-default-features -F examples-crossterm
+//! cargo run --example demo --features crossterm
 //! ```
 //!
 //! ## `slog` support


### PR DESCRIPTION
Updated the demo example to use features from the latest version of the
`ratatui` crate and simplified the application model significantly. Note
that the main crate is still compatible with `ratatui` version `0.25.0`,
but the demo example uses features from `0.26.0`.

Moved the optional dependencies on `termion` and `crossterm` to the
`dev-dependencies` section of the `Cargo.toml` file, and made them
mutually exclusive in the demo example. Moved the backend specific code
into seperate modules.

To run the demo, use either of the following commands:

```shell
cargo run --example demo --features crossterm
cargo run --example demo --features termion
```

Added a bacon config file to make it easy to check that the demo
compiles with the `crossterm` and `termion` features enabled.

---

Note: includes changes from #55, which is a breaking change that should probably be merged separately this.