### PR TITLE
Implement Cargo Semver Checks github action - resolves #62

### DIFF
--- a/.github/workflows/semver_checks.yml
+++ b/.github/workflows/semver_checks.yml
@@ -1,0 +1,16 @@
+name: Semver Checks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
This PR implements a simple cargo-semver-checks github action that will run on push/PR to this repo. I considered the alternative of only running this action on publish but I was not sure what your workflow is.

You can test this locally using nektos/act - the full size docker image option is required.