### PR TITLE
Update ratatui to 0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.11.3:
+- update ratatui to 0.28
+
 0.11.2:
 - update ratatui to 0.27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-logger"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Jochen Kiemes <jochen@kiemes.de>"]
 edition = "2021"
 license = "MIT"
@@ -16,7 +16,7 @@ travis-ci = { repository = "gin66/tui-logger" }
 [dependencies]
 log = "0.4"
 chrono = { version = "^0.4.20", default-features = false, features = ["clock"] }
-ratatui = { version = "0.27", default-features = false}
+ratatui = { version = "0.28", default-features = false}
 tracing = {version = "0.1.37", optional = true}
 tracing-subscriber = {version = "0.3", optional = true}
 lazy_static = "1.0"
@@ -26,7 +26,7 @@ slog = { version = "2.7.0", optional = true }
 
 [dev-dependencies]
 # the crate is compatible with ratatui >=0.25.0, but the demo uses features from 0.27.0
-ratatui = { version = "0.27", default-features = false}
+ratatui = { version = "0.28", default-features = false}
 anyhow = "1.0.79"
 env_logger = "0.11.1"
 termion = {version = "3.0.0" }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -154,7 +154,7 @@ impl App {
 
     fn draw(&mut self, terminal: &mut Terminal<impl Backend>) -> anyhow::Result<()> {
         terminal.draw(|frame| {
-            frame.render_widget(self, frame.size());
+            frame.render_widget(self, frame.area());
         })?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,25 +839,26 @@ impl<'b> Widget for TuiLoggerTargetWidget<'b> {
                     (3, "D", Level::Debug),
                     (4, "T", Level::Trace),
                 ] {
-                    let cell = buf.get_mut(la_left + j, la_top + i as u16);
-                    let cell_style = if *hot_level_filter >= *lev {
-                        if *level_filter >= *lev {
-                            if !focus_selected || i + offset == state.selected {
-                                self.style_show
+                    if let Some(cell) = buf.cell_mut((la_left + j, la_top + i as u16)) {
+                        let cell_style = if *hot_level_filter >= *lev {
+                            if *level_filter >= *lev {
+                                if !focus_selected || i + offset == state.selected {
+                                    self.style_show
+                                } else {
+                                    self.style_hide
+                                }
                             } else {
                                 self.style_hide
                             }
+                        } else if let Some(style_off) = self.style_off {
+                            style_off
                         } else {
-                            self.style_hide
-                        }
-                    } else if let Some(style_off) = self.style_off {
-                        style_off
-                    } else {
-                        cell.set_symbol(" ");
-                        continue;
-                    };
-                    cell.set_style(cell_style);
-                    cell.set_symbol(sym);
+                            cell.set_symbol(" ");
+                            continue;
+                        };
+                        cell.set_style(cell_style);
+                        cell.set_symbol(sym);
+                    }
                 }
                 buf.set_stringn(la_left + 5, la_top + i as u16, ":", la_width, self.style);
                 buf.set_stringn(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,12 +203,16 @@ use std::io::Write;
 use std::mem;
 use std::sync::Arc;
 
-use ratatui::prelude::*;
-use ratatui::widgets::*;
-
 use chrono::{DateTime, Local};
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use parking_lot::Mutex;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::Line,
+    widgets::{Block, BorderType, Borders, Widget},
+};
 
 mod circular;
 #[cfg(feature = "slog-support")]


### PR DESCRIPTION
Hi, I'm currently in the process of using your crate and so far it worked out quite nice for my use case. The only problem I faced was conflicting `ratatui` versions.

This PR updates `ratatui` to `0.28` and adjusts the (now) deprecated functions.