### PR TITLE
Add docs for tracing_subscriber/slog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,15 @@ feature_crossterm_or_termion_must_be_selected = []
 crossterm = ["ratatui/crossterm", "feature_crossterm_or_termion_must_be_selected"]
 termion = ["ratatui/termion", "feature_crossterm_or_termion_must_be_selected"]
 
+# Docs.rs-specific configuration required to enable documentation of
+# code requiring optional features.
+[package.metadata.docs.rs]
+# Document all features
+all-features = true
+# Defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[example]]
 name="demo"
 required-features=["feature_crossterm_or_termion_must_be_selected"]
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,14 +126,14 @@
 //!
 //! ## `slog` support
 //!
-//! `tui-logger` provides a TuiSlogDrain which implements `slog::Drain` and will route all records
+//! `tui-logger` provides a [`TuiSlogDrain`] which implements `slog::Drain` and will route all records
 //! it receives to the `tui-logger` widget.
 //!
 //! Enabled by feature "slog-support"
 //!
 //! ## `tracing-subscriber` support
 //!
-//! `tui-logger` provides a TuiTracingSubscriberLayer which implements
+//! `tui-logger` provides a [`TuiTracingSubscriberLayer`] which implements
 //! `tracing_subscriber::Layer` and will collect all events
 //! it receives to the `tui-logger` widget
 //!
@@ -193,6 +193,8 @@
 //!## Star History
 //!
 //![![Star History Chart](https://api.star-history.com/svg?repos=gin66/tui-logger&type=Date)](https://star-history.com/#gin66/tui-logger&Date)
+// Enable docsrs doc_cfg - to display non-default feature documentation.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[macro_use]
 extern crate lazy_static;
 
@@ -219,14 +221,18 @@ use ratatui::{
 
 mod circular;
 #[cfg(feature = "slog-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "slog-support")))]
 mod slog;
 #[cfg(feature = "tracing-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing-support")))]
 mod tracing_subscriber;
 
 pub use crate::circular::CircularBuffer;
 #[cfg(feature = "slog-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "slog-support")))]
 pub use crate::slog::TuiSlogDrain;
 #[cfg(feature = "tracing-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing-support")))]
 pub use crate::tracing_subscriber::TuiTracingSubscriberLayer;
 
 struct ExtLogRecord {
@@ -444,11 +450,13 @@ pub fn init_logger(max_level: LevelFilter) -> Result<(), log::SetLoggerError> {
 }
 
 #[cfg(feature = "slog-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "slog-support")))]
 pub fn slog_drain() -> TuiSlogDrain {
     TuiSlogDrain
 }
 
 #[cfg(feature = "tracing-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing-support")))]
 pub fn tracing_subscriber_layer() -> TuiTracingSubscriberLayer {
     TuiTracingSubscriberLayer
 }

--- a/src/tracing_subscriber.rs
+++ b/src/tracing_subscriber.rs
@@ -61,6 +61,17 @@ impl<'a> tracing::field::Visit for ToStringVisitor<'a> {
 #[allow(clippy::needless_doctest_main)]
 ///  tracing-subscriber-compatible layer that feeds messages to `tui-logger`.
 ///
+///  ## How it works
+///  Under the hood, tui_logger still uses `log`. `tracing` events are mapped to
+///  `log` events internally (which are then fed to `tui-logger`).
+///
+///  ## Limitations
+///  The TuiTracingSubscriberLayer currently is locked set to have a default
+///  filter for events of `Info` state or higher. This is not able to be changed
+///  currently without adding a depency on the `log` crate, as the
+///  [init_logger()] function that sets the filter level takes `log`'s event types.
+///
+///  [init_logger()]: super::init_logger()
 ///  ## Basic usage:
 ///  ```
 ///  //use tui_logger;


### PR DESCRIPTION
Closes #67.

1. Utilises the `doc_cfg` attribute to show documentation for non-default docs by default on docs.rs. This also benefits the `slog` feature. https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577
2. Added some implementation information and information about #66 to the pre-existing docs

This will build as expected on docs.rs with no additional effort as they run nightly rust. However, to build docs locally, you will need to run the following command to mimic docs.rs environment.
```
cargo +nightly rustdoc -p tui-logger --all-features -- --cfg docsrs
```

Here's an example of the new page for `TuiTracingSubscriberLayer`
![image](https://github.com/user-attachments/assets/f66930c8-6643-447a-ac11-8749052fbc5c)
