### PR TITLE
Re-export log::LevelFilter and update docs to match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tui-logger"
-version = "0.13.3"
+version = "0.14.0"
 authors = ["Jochen Kiemes <jochen@kiemes.de>"]
 edition = "2021"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ use std::sync::Arc;
 use std::thread;
 
 use chrono::{DateTime, Local};
-use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
+use log::{Level, Log, Metadata, Record, SetLoggerError};
 use parking_lot::Mutex;
 use ratatui::{
     buffer::Buffer,
@@ -245,6 +245,8 @@ pub use crate::slog::TuiSlogDrain;
 #[cfg(feature = "tracing-support")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tracing-support")))]
 pub use crate::tracing_subscriber::TuiTracingSubscriberLayer;
+#[doc(no_inline)]
+pub use log::LevelFilter;
 
 struct ExtLogRecord {
     timestamp: DateTime<Local>,
@@ -486,7 +488,7 @@ impl std::fmt::Display for TuiLoggerError {
     }
 }
 
-/// Init the logger and record with `log` crate.
+/// Init the logger.
 pub fn init_logger(max_level: LevelFilter) -> Result<(), TuiLoggerError> {
     let join_handle = thread::Builder::new()
         .name("tui-logger::move_events".into())

--- a/src/tracing_subscriber.rs
+++ b/src/tracing_subscriber.rs
@@ -65,24 +65,22 @@ impl<'a> tracing::field::Visit for ToStringVisitor<'a> {
 ///  Under the hood, tui_logger still uses `log`. `tracing` events are mapped to
 ///  `log` events internally (which are then fed to `tui-logger`).
 ///
-///  ## Limitations
-///  The TuiTracingSubscriberLayer currently is locked set to have a default
-///  filter for events of `Info` state or higher. This is not able to be changed
-///  currently without adding a depency on the `log` crate, as the
-///  [init_logger()] function that sets the filter level takes `log`'s event types.
+///  ## Usage note
+///  As per the example below, [init_logger()] must be called prior to logging events.
 ///
-///  [init_logger()]: super::init_logger()
-///  ## Basic usage:
+///  [init_logger()]: crate::init_logger()
+///  ## Basic usage
 ///  ```
-///  //use tui_logger;
+///  use tracing_subscriber::prelude::*;
 ///
 ///  fn main() {
 ///     tracing_subscriber::registry()
 ///          .with(tui_logger::tracing_subscriber_layer())
 ///          .init();
-///     tui_logger::init_logger(LevelFilter::Trace).unwrap();
-///     info!(log, "Logging via tracing works!");
+///     tui_logger::init_logger(tui_logger::LevelFilter::Trace).unwrap();
+///     tracing::info!("Logging via tracing works!");
 ///  }
+///  ```
 pub struct TuiTracingSubscriberLayer;
 
 impl<S> Layer<S> for TuiTracingSubscriberLayer


### PR DESCRIPTION
Noticed with 0.14.0, `tui_logger::init()` is now used to set log level when using tracing. This is nice because I can now use different log levels than the old default (info or higher).

I have updated the docs to remove the 'limitation' I added previously in #68 as it has been resolved.

I also added `log::LevelFilter` as a re-export, as it is required as a parameter to `init()`, and tracing users are not likely to import `log`. This should be a non-breaking change as far as I am aware, `log` users can continue to use `log::LevelFilter` and tracing users can start using `tui_logger::LevelFilter` and I have tested this locally.

Finally, version num has been bumped to match crates.io.