### PR TITLE
fix formatter for tracing events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1178,7 +1178,7 @@ impl<'b> TuiLoggerWidget<'b> {
         let (col_style, lev_long, lev_abbr, with_loc) = match evt.level {
             log::Level::Error => (self.style_error, "ERROR", "E", true),
             log::Level::Warn => (self.style_warn, "WARN ", "W", true),
-            log::Level::Info => (self.style_info, "INFO ", "I", false),
+            log::Level::Info => (self.style_info, "INFO ", "I", true),
             log::Level::Debug => (self.style_debug, "DEBUG", "D", true),
             log::Level::Trace => (self.style_trace, "TRACE", "T", true),
         };

--- a/src/tracing_subscriber.rs
+++ b/src/tracing_subscriber.rs
@@ -2,12 +2,12 @@
 
 use super::TUI_LOGGER;
 use log::{self, Log, Record};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 use tracing_subscriber::Layer;
 
 #[derive(Default)]
-struct ToStringVisitor<'a>(HashMap<&'a str, String>);
+struct ToStringVisitor<'a>(BTreeMap<&'a str, String>);
 
 impl fmt::Display for ToStringVisitor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
 - switch HashMap to BTreeMap to ensure keys are always in the same order

Before:
![tui-random-field-order](https://github.com/user-attachments/assets/2ed00c98-6281-4bcf-b6eb-7bf545a060a6)

After:
![tui-ordered-fields](https://github.com/user-attachments/assets/d63277bb-12a4-4d4a-89fb-a414e0ba1274)
