### PR TITLE
do not print the 'message' key in the formatter for tracing support

### DIFF
--- a/src/tracing_subscriber.rs
+++ b/src/tracing_subscriber.rs
@@ -11,9 +11,13 @@ struct ToStringVisitor<'a>(HashMap<&'a str, String>);
 
 impl fmt::Display for ToStringVisitor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0
-            .iter()
-            .try_for_each(|(k, v)| -> fmt::Result { write!(f, " {}: {}", k, v) })
+        self.0.iter().try_for_each(|(k, v)| -> fmt::Result {
+            if *k == "message" {
+                write!(f, " {}", v)
+            } else {
+                write!(f, " {}: {}", k, v)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Noticed that when `tracing-support` is used, the key 'message' is used before every log message which makes it unecessarily verbose. 
I also noticed that when using standalone `tracing` to log to a file, independent of this crate, the `message` key is not printed before the log, e.g., in the file I get
```
2025-01-12T11:48:26  INFO : Full log available in: .....
```
while in the TUI I get
```
2025-01-12 11:48:26 :INFO : message: Full log available in: .....
```