### PR TITLE
Split lines safely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.5"
 fxhash = "0.2"
 parking_lot = "0.12"
 slog = { version = "2.7.0", optional = true }
+unicode-segmentation = "1.12.0"
 
 [dev-dependencies]
 # the crate is compatible with ratatui >=0.25.0, but the demo uses features from 0.27.0

--- a/src/widget/smart.rs
+++ b/src/widget/smart.rs
@@ -1,6 +1,7 @@
 use crate::widget::logformatter::LogFormatter;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use unicode_segmentation::UnicodeSegmentation;
 
 use log::LevelFilter;
 use ratatui::{
@@ -261,7 +262,7 @@ impl<'a> Widget for TuiLoggerSmartWidget<'a> {
                         if hide_off && levelfilter == &LevelFilter::Off {
                             continue;
                         }
-                        width = width.max(t.len())
+                        width = width.max(t.graphemes(true).count())
                     }
                 }
             }

--- a/src/widget/standard_formatter.rs
+++ b/src/widget/standard_formatter.rs
@@ -40,19 +40,27 @@ impl LogStandardFormatter {
         let space = " ".repeat(indent);
         while p < line.len() {
             let linelen = std::cmp::min(wrap_len, line.len() - p);
-            let subline = &line[p..p + linelen];
+            let subline = line
+                .chars()
+                .skip(p)
+                .take(linelen)
+                .map(|char| {
+                    let mut buf = [0; 4];
+                    char.encode_utf8(&mut buf).to_string()
+                })
+                .collect::<String>();
 
             let mut spans: Vec<Span> = Vec::new();
             if wrap_len < width {
                 // need indent
                 spans.push(Span {
-                    style: style,
+                    style,
                     content: Cow::Owned(space.to_string()),
                 });
             }
             spans.push(Span {
-                style: style,
-                content: Cow::Owned(subline.to_string()),
+                style,
+                content: Cow::Owned(subline),
             });
             let line = Line::from(spans);
             lines.push(line);


### PR DESCRIPTION
Previously if a unicode char that was longer then 1 byte was split the whole program panicked.
test case:
add 
```rust
error!(target: "background-task", "これは日本語の誤りですこれは日本語の誤りです");
```
to background task in the demo. You may need to resize you terminal to get it to split.

This pull request would fix this issue.
However the character might not be displayed correctly because they may be bigger then normals ones, in my case they are exactly twice as large. I don't see this as a big issue but I felt like I should mention it.