### PR TITLE
docs: Fix invalid docs for TuiTracingSubscriberLayer (#87)

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -16,4 +16,6 @@ jobs:
       - name: Check rust version
         run: rustup show
       - name: Run tests
-        run: cargo test
+        run: |
+          cargo test
+          cargo test -F tracing-support --doc

--- a/src/tracing_subscriber.rs
+++ b/src/tracing_subscriber.rs
@@ -6,11 +6,6 @@ use std::collections::BTreeMap;
 use std::fmt;
 use tracing_subscriber::Layer;
 
-#[cfg_attr(docsrs, doc(cfg(feature = "tracing-support")))]
-pub fn tracing_subscriber_layer() -> TuiTracingSubscriberLayer {
-    TuiTracingSubscriberLayer
-}
-
 #[derive(Default)]
 struct ToStringVisitor<'a>(BTreeMap<&'a str, String>);
 
@@ -84,7 +79,7 @@ impl<'a> tracing::field::Visit for ToStringVisitor<'a> {
 ///
 ///  fn main() {
 ///     tracing_subscriber::registry()
-///          .with(tui_logger::tracing_subscriber_layer())
+///          .with(tui_logger::TuiTracingSubscriberLayer)
 ///          .init();
 ///     tui_logger::init_logger(tui_logger::LevelFilter::Trace).unwrap();
 ///     tracing::info!("Logging via tracing works!");


### PR DESCRIPTION
Hi there, I noticed in #87 that `tui_logger::tracing_subscriber_layer()` was removed from the public API accidentally in a previous refactoring.

I think that's not a bad thing since the function didn't really do anything and just constructed a literal `TuiTracingSubscriberLayer`.

So I'm proposing in this PR to remove `tui_logger::tracing_subscriber_layer()` and update the docs to reflect users should use `TuiTracingSubscriberLayer` directly.

It looks like this would have been picked up by the doctest but it requires the feature enabled to run in CI, so have added that step.