### PR TITLE
fix: add missing `Verbose` match arm for `LevelFilter`

### DIFF
--- a/src/widget/target.rs
+++ b/src/widget/target.rs
@@ -16,7 +16,8 @@ use log::LevelFilter;
 
 fn advance_levelfilter(levelfilter: LevelFilter) -> (Option<LevelFilter>, Option<LevelFilter>) {
     match levelfilter {
-        LevelFilter::Trace => (None, Some(LevelFilter::Debug)),
+        LevelFilter::Verbose => (None, Some(LevelFilter::Trace)),
+        LevelFilter::Trace => (Some(LevelFilter::Verbose), Some(LevelFilter::Debug)),
         LevelFilter::Debug => (Some(LevelFilter::Trace), Some(LevelFilter::Info)),
         LevelFilter::Info => (Some(LevelFilter::Debug), Some(LevelFilter::Warn)),
         LevelFilter::Warn => (Some(LevelFilter::Info), Some(LevelFilter::Error)),


### PR DESCRIPTION
Fixes a compilation error caused by missing match arm on `LevelFilter`:

```console
coko7@linux:~$ cargo build

Compiling tui-logger v0.18.1
error[E0004]: non-exhaustive patterns: `LevelFilter::Verbose` not covered
   --> src/widget/target.rs:18:11
    |
 18 |     match levelfilter {
    |           ^^^^^^^^^^^ pattern `LevelFilter::Verbose` not covered
    |
note: `LevelFilter` defined here
   --> /home/coko7/.config/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-0.4.29/src/lib.rs:636:1
    |
636 | pub enum LevelFilter {
    | ^^^^^^^^^^^^^^^^^^^^
...
649 |     Verbose,
    |     ------- not covered
    = note: the matched value is of type `LevelFilter`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 24 ~         LevelFilter::Off => (Some(LevelFilter::Error), None),
 25 ~         LevelFilter::Verbose => todo!(),
    |

For more information about this error, try `rustc --explain E0004`.
error: could not compile `tui-logger` (lib) due to 1 previous error
```